### PR TITLE
Delete protocol from button category

### DIFF
--- a/FSQComponents/FSQComponents/Components/FSQComponentButtonModel.h
+++ b/FSQComponents/FSQComponents/Components/FSQComponentButtonModel.h
@@ -39,7 +39,7 @@
 
 @end
 
-@interface UIButton (FSQComponentButton) <FSQComposable>
+@interface UIButton (FSQComponentButton)
 
 - (void)configureWithViewModel:(FSQComponentButtonModel *)model;
 


### PR DESCRIPTION
So that swift doesn't complain when we put BurritoButton in the bridging header