### PR TITLE
Fix assert check

### DIFF
--- a/FSQComponents/FSQComponents/FSQComponentSpecification.m
+++ b/FSQComponents/FSQComponents/FSQComponentSpecification.m
@@ -24,7 +24,7 @@
 
 - (instancetype)initWithViewModel:(id)viewModel viewClass:(Class)viewClass insets:(UIEdgeInsets)insets {
     if ((self = [super init])) {
-        NSAssert([viewClass conformsToProtocol:@protocol(FSQComposable)], @"Attempting to create a FSQComponentSpecification with an invalid viewClass.");
+        NSAssert([viewClass conformsToProtocol:@protocol(FSQComposable)] || viewClass == [UIButton class], @"Attempting to create a FSQComponentSpecification with an invalid viewClass.");
         _viewModel = viewModel;
         _viewClass = viewClass;
         _insets = insets;


### PR DESCRIPTION
fix assert that is now a side effect from not making UIButton conforming to the FSQComposable protocol, since UIButton is always conforming (from it's category) we should just allow this class itself to pass through